### PR TITLE
增加 LCK 比赛日历

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,6 +183,9 @@ async function dealLCKGames() {
     
     // 生成各队伍有提醒和无提醒的文件
     let teams = games.map(function(item) {
+        if (item.opponents.length <= 0) {
+            return []
+        }
         return [item.opponents[0].opponent.acronym, item.opponents[1].opponent.acronym]
     });
     let teamNames = [...new Set(teams.flat())];

--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ function generateLCKICSAndWrite(games, fileName) {
 }
 
 function lckGamesToICSObjs(game, hasAlarm, yearStr) {
-    const gameDate = new Date(new Date(game.original_scheduled_at).getTime() - 8 * 60 * 60 * 1000);
+    const gameDate = new Date(new Date(game.scheduled_at).getTime() - 8 * 60 * 60 * 1000);
     const gameEndDate = new Date(gameDate.getTime() + 2 * 60 * 60 * 1000);
     let slug = game.slug;
     let gameName = game.name;

--- a/index.js
+++ b/index.js
@@ -224,9 +224,6 @@ function lckGamesToICSObjs(game, hasAlarm, yearStr) {
         description: slug,
         start: [gameDate.getFullYear(), gameDate.getMonth() + 1, gameDate.getDate(), gameDate.getHours(), gameDate.getMinutes()],
         end: [gameEndDate.getFullYear(), gameEndDate.getMonth() + 1, gameEndDate.getDate(), gameEndDate.getHours(), gameEndDate.getMinutes()],
-        organizer: {
-            name: slug
-        },
         url: "https://www.twitch.tv/lck",
         status: "TENTATIVE",
         calName: `${yearStr}_lck`,


### PR DESCRIPTION
[issues#3](https://github.com/TankNee/LOL_Game_Subscription/issues/3)

数据来源：https://pandascore.co ，有每小时免费使用额度：1000 in last hour，注册后生成 TOKEN

运行请先设置环境变量
```
export TOKEN=xxxx
```

Github Actions 需要在仓库 `Settings - Security -  Secrets and variables - Actions - Variables` 设置 TOKEN

由于不会写 JavaScript，代码基本靠问 GPT 完成，本地测试没发现问题

一些不同的地方：移除了 `ORGANIZER;CN` 字段；移除了 `GEO` 字段


